### PR TITLE
Update jelly-cli and use jelly-rdf/setup-cli

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -22,14 +22,10 @@ jobs:
           cache: pip
           cache-dependency-path: requirements.txt
   
+      - uses: Jelly-RDF/setup-cli@v1
+
       - name: Install dependencies
         run: pip install -r requirements.txt
-
-      - name: Install jelly-cli
-        run: |
-          wget -O /opt/jelly-cli https://github.com/Jelly-RDF/cli/releases/download/v0.2.0/jelly-cli-linux-x86_64
-          chmod +x /opt/jelly-cli
-          echo '/opt' >> $GITHUB_PATH
 
       - name: 'Convert ontologies, prepare for publishing'
         run: |

--- a/bin/build_ontology.sh
+++ b/bin/build_ontology.sh
@@ -6,12 +6,11 @@
 
 # Run this script from the root of the repository.
 
-# TODO: add support for outputting to JSON-LD and RDF/XML in jelly-cli
 formats=(
   "ttl"
-  #"jsonld"
+  "jsonld"
   "nt"
-  #"rdf"
+  "rdf"
 )
 
 mkdir -p publish

--- a/docs/ontology/aggregates.md
+++ b/docs/ontology/aggregates.md
@@ -8,6 +8,8 @@
 | **Turtle** | [`https://w3id.org/rdf-tensor/aggregates.ttl`](https://w3id.org/rdf-tensor/aggregates.ttl) |
 | **N-Triples** | [`https://w3id.org/rdf-tensor/aggregates.nt`](https://w3id.org/rdf-tensor/aggregates.nt) |
 | [**Jelly**](https://w3id.org/jelly) | [`https://w3id.org/rdf-tensor/aggregates.jelly`](https://w3id.org/rdf-tensor/aggregates.jelly) |
+| **JSON-LD** | [`https://w3id.org/rdf-tensor/aggregates.jsonld`](https://w3id.org/rdf-tensor/aggregates.jsonld) |
+| **RDF/XML** | [`https://w3id.org/rdf-tensor/aggregates.rdf`](https://w3id.org/rdf-tensor/aggregates.rdf) |
 
 ## Ontology source
 

--- a/docs/ontology/datatypes.md
+++ b/docs/ontology/datatypes.md
@@ -8,6 +8,8 @@
 | **Turtle** | [`https://w3id.org/rdf-tensor/datatypes.ttl`](https://w3id.org/rdf-tensor/datatypes.ttl) |
 | **N-Triples** | [`https://w3id.org/rdf-tensor/datatypes.nt`](https://w3id.org/rdf-tensor/datatypes.nt) |
 | [**Jelly**](https://w3id.org/jelly) | [`https://w3id.org/rdf-tensor/datatypes.jelly`](https://w3id.org/rdf-tensor/datatypes.jelly) |
+| **JSON-LD** | [`https://w3id.org/rdf-tensor/datatypes.jsonld`](https://w3id.org/rdf-tensor/datatypes.jsonld) |
+| **RDF/XML** | [`https://w3id.org/rdf-tensor/datatypes.rdf`](https://w3id.org/rdf-tensor/datatypes.rdf) |
 
 ## Ontology source
 

--- a/docs/ontology/functions.md
+++ b/docs/ontology/functions.md
@@ -8,6 +8,8 @@
 | **Turtle** | [`https://w3id.org/rdf-tensor/functions.ttl`](https://w3id.org/rdf-tensor/functions.ttl) |
 | **N-Triples** | [`https://w3id.org/rdf-tensor/functions.nt`](https://w3id.org/rdf-tensor/functions.nt) |
 | [**Jelly**](https://w3id.org/jelly) | [`https://w3id.org/rdf-tensor/functions.jelly`](https://w3id.org/rdf-tensor/functions.jelly) |
+| **JSON-LD** | [`https://w3id.org/rdf-tensor/functions.jsonld`](https://w3id.org/rdf-tensor/functions.jsonld) |
+| **RDF/XML** | [`https://w3id.org/rdf-tensor/functions.rdf`](https://w3id.org/rdf-tensor/functions.rdf) |
 
 ## Ontology source
 


### PR DESCRIPTION
Jelly CLI now has [`jelly-rdf/setup-cli` GitHub Action](https://github.com/marketplace/actions/setup-jelly-cli) for easier installation in GitHub CI/CD workflows. Additionally, since version 0.5.0, `jelly-cli` now supports JSON-LD and RDF/XML output formats ([changelog](https://github.com/Jelly-RDF/cli/releases/tag/v0.5.0)).

This PR changes the installation method to the new action, which will also update `jelly-cli` to the latest version (v0.5.2 as of writing). This PR will also enable `build_ontology.sh` to also output JSON-LD and RDF/XML, since support is now available in `jelly-cli`.